### PR TITLE
A user can check out a book

### DIFF
--- a/priv/repo/migrations/20160927210940_create_book.exs
+++ b/priv/repo/migrations/20160927210940_create_book.exs
@@ -8,8 +8,6 @@ defmodule Bookish.Repo.Migrations.CreateBook do
       add :author_lastname, :string
       add :year, :integer
       add :current_location, :string
-      add :checked_out, :boolean, default: false, null: false
-      add :checked_out_to, :string
 
       timestamps()
     end

--- a/priv/repo/migrations/20161002213257_create_check_out.exs
+++ b/priv/repo/migrations/20161002213257_create_check_out.exs
@@ -1,0 +1,13 @@
+defmodule Bookish.Repo.Migrations.CreateCheckOut do
+  use Ecto.Migration
+
+  def change do
+    create table(:check_outs) do
+      add :book_id, :integer
+      add :checked_out_to, :string
+      add :return_date, :date
+
+      timestamps()
+    end
+  end
+end

--- a/test/controllers/book_controller_test.exs
+++ b/test/controllers/book_controller_test.exs
@@ -2,6 +2,7 @@ defmodule Bookish.BookControllerTest do
   use Bookish.ConnCase
 
   alias Bookish.Book
+
   @valid_attrs %{author_firstname: "some content", author_lastname: "some content", current_location: "some content", title: "some content", year: 2016}
   @invalid_attrs %{}
 
@@ -10,28 +11,28 @@ defmodule Bookish.BookControllerTest do
     assert conn.status == 200
   end
 
-  test "lists all entries on index", %{conn: conn} do
+  test "lists all books on index", %{conn: conn} do
     conn = get conn, book_path(conn, :index)
     assert conn.status == 200
   end
 
-  test "renders form for new resources", %{conn: conn} do
+  test "renders form to add a new book", %{conn: conn} do
     conn = get conn, book_path(conn, :new)
     assert html_response(conn, 200) =~ "New book"
   end
 
-  test "creates resource and redirects when data is valid", %{conn: conn} do
+  test "creates new book and redirects when data is valid", %{conn: conn} do
     conn = post conn, book_path(conn, :create), book: @valid_attrs
     assert redirected_to(conn) == book_path(conn, :index)
     assert Repo.get_by(Book, @valid_attrs)
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+  test "does not create book and renders errors when data is invalid", %{conn: conn} do
     conn = post conn, book_path(conn, :create), book: @invalid_attrs
     assert html_response(conn, 200) =~ "New book"
   end
 
-  test "shows chosen resource", %{conn: conn} do
+  test "shows details for a book", %{conn: conn} do
     book = Repo.insert! %Book{}
     conn = get conn, book_path(conn, :show, book)
     assert html_response(conn, 200) =~ "Show book"
@@ -43,29 +44,30 @@ defmodule Bookish.BookControllerTest do
     end
   end
 
-  test "renders form for editing chosen resource", %{conn: conn} do
+  test "renders form for editing a book", %{conn: conn} do
     book = Repo.insert! %Book{}
     conn = get conn, book_path(conn, :edit, book)
     assert html_response(conn, 200) =~ "Edit book"
   end
 
-  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+  test "updates a book and redirects when data is valid", %{conn: conn} do
     book = Repo.insert! %Book{}
     conn = put conn, book_path(conn, :update, book), book: @valid_attrs
     assert redirected_to(conn) == book_path(conn, :show, book)
     assert Repo.get_by(Book, @valid_attrs)
   end
 
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+  test "does not update book and renders errors when data is invalid", %{conn: conn} do
     book = Repo.insert! %Book{}
     conn = put conn, book_path(conn, :update, book), book: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit book"
   end
 
-  test "deletes chosen resource", %{conn: conn} do
+  test "deletes a book", %{conn: conn} do
     book = Repo.insert! %Book{}
     conn = delete conn, book_path(conn, :delete, book)
     assert redirected_to(conn) == book_path(conn, :index)
     refute Repo.get(Book, book.id)
   end
+
 end

--- a/test/controllers/check_out_controller_test.exs
+++ b/test/controllers/check_out_controller_test.exs
@@ -1,0 +1,54 @@
+defmodule Bookish.CheckOutControllerTest do
+  use Bookish.ConnCase
+
+  alias Bookish.CheckOut
+  alias Bookish.Book
+  @valid_attrs %{checked_out_to: "A person"}
+  @invalid_attrs %{}
+  
+  test "lists all entries on index", %{conn: conn} do
+    book = Repo.insert! %Book{}
+    conn = get conn, book_check_out_path(conn, :index, book)
+    assert html_response(conn, 200) =~ "Listing check outs"
+  end
+
+  test "renders form to check out a book", %{conn: conn} do
+    book = Repo.insert! %Book{} 
+    conn = get conn, book_check_out_path(conn, :new, book)
+    assert conn.status == 200 
+  end
+
+  test "creates new check-out record and redirects when data is valid", %{conn: conn} do
+    book = Repo.insert! %Book{} 
+    conn = post conn, book_check_out_path(conn, :create, book), check_out: @valid_attrs
+    assert redirected_to(conn) == book_path(conn, :index)
+    assert Repo.get_by(CheckOut, @valid_attrs)
+  end
+
+  test "does not create new check-out record and renders errors when data is invalid", %{conn: conn} do
+    book = Repo.insert! %Book{}
+    conn = post conn, book_check_out_path(conn, :create, book), check_out: @invalid_attrs
+    refute Repo.get_by(CheckOut, @invalid_attrs)
+    assert conn.status == 200
+  end
+
+  test "does not show new check-out page if a book is already checked out and redirects to the index", %{conn: conn} do
+    book = Repo.insert! %Book{}
+    check_out = 
+      Ecto.build_assoc(book, :check_outs, checked_out_to: "Person")
+    Repo.insert!(check_out)
+    conn = get conn, book_check_out_path(conn, :new, book)
+    assert redirected_to(conn) == book_path(conn, :index)
+  end
+
+  test "does not create a new check-out record if a book is already checked out", %{conn: conn} do
+    book = Repo.insert! %Book{}
+    check_out = 
+      Ecto.build_assoc(book, :check_outs, checked_out_to: "Person")
+
+    Repo.insert!(check_out)
+    post conn, book_check_out_path(conn, :create, book), check_out: @valid_attrs
+
+    refute Repo.get_by(CheckOut, @valid_attrs)
+  end
+end

--- a/test/controllers/circulation_test.exs
+++ b/test/controllers/circulation_test.exs
@@ -1,0 +1,59 @@
+defmodule Bookish.CirculationTest do
+  use Bookish.ConnCase
+
+  alias Bookish.Circulation 
+  alias Bookish.Book
+
+  @book_attrs %{author_firstname: "some content", author_lastname: "some content", current_location: "some content", title: "some content", year: 2016}
+
+  test "checked_out? returns false if no check_out record exists for the book" do
+    book = Repo.insert! %Book{} 
+    refute Circulation.checked_out?(book)
+  end
+  
+  test "checked_out? returns true if a check_out record exists for the book" do
+    book = Repo.insert! %Book{}
+    check_out = 
+      Ecto.build_assoc(book, :check_outs, checked_out_to: "Person")
+    Repo.insert!(check_out)
+    assert Circulation.checked_out?(book) 
+  end
+
+  test "checked_out_to returns the name of the person the book is checked out to" do
+    book = Repo.insert! %Book{}
+    check_out = 
+      Ecto.build_assoc(book, :check_outs, checked_out_to: "Person")
+    Repo.insert!(check_out)
+    assert Circulation.checked_out_to(book) == "Person"
+  end
+
+  test "checked_out_to returns nil if the book is currently available" do
+    book = Repo.insert! %Book{}
+    assert is_nil(Circulation.checked_out_to(book))
+  end
+
+  test "set virtual attributes returns an unchanged collection of books if no books are checked out" do
+    book = Repo.insert! %Book{}
+    coll = [book]
+    assert Circulation.set_virtual_attributes(coll) == coll
+  end
+
+  test "check_out updates the current location and returns the changed book", %{conn: conn} do
+    book = Repo.insert! %Book{"current_location": "A place"}
+    conn = post conn, book_check_out_path(conn, :create, book), check_out: %{"checked_out_to": "Person"} 
+    updated_book = Circulation.check_out(conn)
+    assert is_nil(updated_book.current_location) 
+  end
+
+  test "if a check-out record exists for a book in the collection, it returns an updated collection" do
+    book = Repo.insert! %Book{}
+    coll = [book]
+    check_out = 
+      Ecto.build_assoc(book, :check_outs, checked_out_to: "Person")
+    Repo.insert!(check_out)
+    updated_coll = Circulation.set_virtual_attributes(coll)
+    assert List.first(updated_coll).checked_out == true
+    assert List.first(updated_coll).checked_out_to == "Person"
+  end
+end
+

--- a/test/models/book_test.exs
+++ b/test/models/book_test.exs
@@ -40,58 +40,33 @@ defmodule Bookish.BookTest do
     refute changeset.valid?
   end
 
-  @tag :checkout
-  test "checkout is valid with checked_out and checked_out_to" do
-    attributes = %{checked_out: true, checked_out_to: "name", current_location: ""}
-    changeset = Book.checkout(%Book{}, attributes)
-    assert changeset.valid?
+  test "checked_out defaults to false" do
+    book = Repo.insert!(%Book{})
+    refute book.checked_out
   end
 
-  @tag :checkout
-  test "checked out must be true" do
-    attributes = %{checked_out: false, checked_out_to: "name", current_location: ""}
-    changeset = Book.checkout(%Book{}, attributes)
-    refute changeset.valid?
-  end
-
-  @tag :checkout
-  test "checked_out_to must not be an empty string" do
-    attributes = %{checked_out: true, checked_out_to: "", current_location: ""}
-    changeset = Book.checkout(%Book{}, attributes)
-    refute changeset.valid?
+  test "checked_out can be set to true" do
+    book = Repo.insert!(%Book{checked_out: true})
+    assert book.checked_out
   end
 
   @tag :checkout
   test "current_location must be an empty string" do
-    attributes = %{checked_out: true, checked_out_to: "", current_location: "location"}
+    attributes = %{current_location: "location"}
     changeset = Book.checkout(%Book{}, attributes)
     refute changeset.valid?
   end
   
   @tag :return
-  test "return is valid with checked_out and current_location" do
-    attributes = %{checked_out: false, checked_out_to: "", current_location: "location"}
+  test "return is valid with current_location" do
+    attributes = %{current_location: "location"}
     changeset = Book.return(%Book{}, attributes)
     assert changeset.valid?
   end
 
   @tag :return
-  test "checked out must be false" do
-    attributes = %{checked_out: true, checked_out_to: "", current_location: "location"}
-    changeset = Book.return(%Book{}, attributes)
-    refute changeset.valid?
-  end
-
-  @tag :return
-  test "checked_out_to must be an empty string" do
-    attributes = %{checked_out: false, checked_out_to: "name", current_location: "location"}
-    changeset = Book.return(%Book{}, attributes)
-    refute changeset.valid?
-  end
-
-  @tag :return
   test "current location must not be an empty string" do
-    attributes = %{checked_out: false, checked_out_to: "name", current_location: ""}
+    attributes = %{current_location: ""}
     changeset = Book.return(%Book{}, attributes)
     refute changeset.valid?
   end

--- a/test/models/check_out_test.exs
+++ b/test/models/check_out_test.exs
@@ -1,0 +1,47 @@
+defmodule Bookish.CheckOutTest do
+  use Bookish.ModelCase
+
+  alias Bookish.CheckOut
+  alias Bookish.Book
+
+  @valid_attrs %{checked_out_to: "A person", book_id: 1}
+  @invalid_attrs %{}
+
+  test "check-out is valid with checked_out_to and book_id" do
+    changeset = CheckOut.changeset(%CheckOut{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "check-out is invalid with no attributes" do
+    changeset = CheckOut.changeset(%CheckOut{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+
+  test "current returns collection of current check_outs" do
+    check_out = Repo.insert!(%CheckOut{})
+    current_check_out = List.first(CheckOut.current(CheckOut) |> Repo.all)
+
+    assert current_check_out == check_out
+  end
+
+  test "current returns an empty collection if no books are checked out" do
+    {:ok, date} = Ecto.Date.cast(DateTime.utc_now())
+    Repo.insert!(%CheckOut{return_date: date})
+    assert empty? CheckOut.current(CheckOut) |> Repo.all 
+  end
+
+  test "current will return an entry for a single book that is checked out" do
+    book = Repo.insert! %Book{}
+    association =
+      Ecto.build_assoc(book, :check_outs, checked_out_to: "Person")
+    check_out = Repo.insert!(association)
+    current_check_out = List.first(CheckOut.current(CheckOut, book.id) |> Repo.all)
+
+    assert current_check_out == check_out
+  end
+
+
+  def empty?(coll) do
+    is_nil(List.first(coll))
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
 ExUnit.start
 
 Ecto.Adapters.SQL.Sandbox.mode(Bookish.Repo, :manual)
-

--- a/web/controllers/book_controller.ex
+++ b/web/controllers/book_controller.ex
@@ -2,9 +2,11 @@ defmodule Bookish.BookController do
   use Bookish.Web, :controller
 
   alias Bookish.Book
+  alias Bookish.Circulation
 
   def index(conn, _params) do
     books = Repo.all(Book)
+    |> Circulation.set_virtual_attributes 
     render(conn, "index.html", books: books)
   end
 
@@ -58,9 +60,6 @@ defmodule Bookish.BookController do
 
   def delete(conn, %{"id" => id}) do
     book = Repo.get!(Book, id)
-
-    # Here we use delete! (with a bang) because we expect
-    # it to always work (and if it does not, it will raise).
     Repo.delete!(book)
 
     conn

--- a/web/controllers/check_out_controller.ex
+++ b/web/controllers/check_out_controller.ex
@@ -1,0 +1,53 @@
+defmodule Bookish.CheckOutController do
+  use Bookish.Web, :controller
+  
+  plug :assign_book
+
+  alias Bookish.CheckOut
+  alias Bookish.Circulation
+
+  def index(conn, _params) do
+    check_outs = Repo.all(CheckOut)
+    render(conn, "index.html", check_outs: check_outs)
+  end
+
+  def new(conn, _params) do
+    book = conn.assigns[:book]
+    cond do
+      Circulation.checked_out? book ->
+        conn
+        |> put_flash(:error, "Book is already checked out!")
+        |> redirect(to: book_path(conn, :index))
+      true ->
+        changeset = CheckOut.changeset(%CheckOut{})
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def create(conn, %{"check_out" => check_out_params}) do
+    changeset = 
+      conn
+      |> Circulation.check_out 
+      |> build_assoc(:check_outs)
+      |> CheckOut.changeset(check_out_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _check_out} ->
+        conn
+        |> put_flash(:info, "Book has been checked out!")
+        |> redirect(to: book_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  defp assign_book(conn, _opts) do
+    case conn.params do
+      %{"book_id" => book_id} ->
+        book = Repo.get(Bookish.Book, book_id)
+        assign(conn, :book, book)
+      {:ok, _book} ->
+        conn
+    end
+  end
+end

--- a/web/controllers/circulation.ex
+++ b/web/controllers/circulation.ex
@@ -1,0 +1,55 @@
+defmodule Bookish.Circulation do
+  use Bookish.Web, :controller
+
+  alias Bookish.Book
+  alias Bookish.CheckOut
+
+  def checked_out?(book) do
+    not_empty?(CheckOut.current(CheckOut, book.id) |> Repo.all)
+  end
+
+  def id_checked_out?(book_id) do
+    not_empty?(CheckOut.current(CheckOut, book_id) |> Repo.all)
+  end
+
+  def checked_out_to(book) do
+    if checked_out?(book) do
+      record = List.first(CheckOut.current(CheckOut, book.id) |> Repo.all)
+      record.checked_out_to
+    end
+  end
+
+  defp not_empty?(coll) do
+    List.first(coll) != nil
+  end
+
+  def check_out(conn) do
+    changeset = 
+      conn.assigns[:book]
+      |> Repo.preload([:check_outs])
+      |> Book.checkout(%{"current_location": ""})
+    case Repo.update (changeset) do
+      {:ok, book} ->
+        book
+    end
+  end
+
+  def set_virtual_attributes(coll) do
+    coll 
+    |> Enum.map(&(set_attributes(&1)))
+  end
+
+  defp set_attributes(book) do
+    if checked_out?(book) do 
+      changeset = 
+        book
+        |> Book.checkout(%{"checked_out": true, "checked_out_to": checked_out_to(book)})
+      case Repo.update(changeset) do
+        {:ok, book} ->
+          book
+      end
+    else
+      book
+    end
+  end
+end

--- a/web/models/book.ex
+++ b/web/models/book.ex
@@ -7,8 +7,10 @@ defmodule Bookish.Book do
     field :author_lastname, :string
     field :year, :integer
     field :current_location, :string
-    field :checked_out, :boolean, default: false
-    field :checked_out_to, :string
+    field :checked_out, :boolean, virtual: true, default: false
+    field :checked_out_to, :string, virtual: true
+
+    has_many :check_outs, Bookish.CheckOut
 
     timestamps()
   end
@@ -25,17 +27,13 @@ defmodule Bookish.Book do
 
   def checkout(struct, params \\ %{}) do
     struct
-    |> cast(params, [:checked_out, :checked_out_to, :current_location])
-    |> validate_required([:checked_out, :checked_out_to])
-    |> validate_acceptance(:checked_out)
+    |> cast(params, [:checked_out_to, :checked_out, :current_location])
     |> validate_inclusion(:current_location, ["", nil])
   end
 
   def return(struct, params \\ %{}) do
     struct 
-    |> cast(params, [:checked_out, :checked_out_to, :current_location])
-    |> validate_required([:checked_out, :current_location])
-    |> validate_inclusion(:checked_out, [false])
-    |> validate_inclusion(:checked_out_to, ["", nil])
+    |> cast(params, [:current_location])
+    |> validate_required([:current_location])
   end
 end

--- a/web/models/check_out.ex
+++ b/web/models/check_out.ex
@@ -1,0 +1,54 @@
+defmodule Bookish.CheckOut do
+  use Bookish.Web, :model
+  import Ecto.Query
+  alias Bookish.Circulation
+
+  schema "check_outs" do
+    field :checked_out_to, :string
+    field :return_date, Ecto.Date
+    timestamps()
+
+    belongs_to :book, Bookish.Book
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:book_id, :checked_out_to])
+    |> validate_required([:book_id, :checked_out_to])
+    |> validate_not_checked_out
+  end
+
+  defp validate_not_checked_out(changeset) do
+    id = get_field(changeset, :book_id)
+    validate_not_checked_out(changeset, id)
+  end
+
+  defp validate_not_checked_out(changeset, id) when id == nil do
+    changeset
+  end
+
+  defp validate_not_checked_out(changeset, id) do
+    if Circulation.id_checked_out?(id) do
+      changeset
+      |> add_error(:checked_out, "Book is already checked out!")
+    else
+      changeset
+    end
+  end
+
+  def current(query) do
+    from c in query,
+    where: is_nil(c.return_date),
+    select: c
+  end
+
+  def current(query, book_id) do
+    from c in query,
+    where: is_nil(c.return_date),
+    where: c.book_id == ^book_id,
+    select: c
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,6 +18,9 @@ defmodule Bookish.Router do
 
     get "/", PageController, :index
     get "/books/return", BookController, :return
-    resources "/books", BookController
+
+    resources "/books", BookController do
+      resources "/check_outs", CheckOutController
+    end
   end
 end

--- a/web/templates/book/check_out.html.eex
+++ b/web/templates/book/check_out.html.eex
@@ -1,0 +1,23 @@
+<%= render Bookish.SharedView, "_header.html", conn: @conn %>
+
+<h2>Check out this book</h2>
+
+<%= form_for @changeset, book_path(@conn, :update, @book), fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check out the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, "What is your name?", class: "control-label" %>
+    <%= text_input f, :checked_out_to, class: "form-control" %>
+    <%= error_tag f, :checked_out_to %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>
+
+<%= link "Back", to: book_path(@conn, :index) %>

--- a/web/templates/book/index.html.eex
+++ b/web/templates/book/index.html.eex
@@ -22,7 +22,7 @@
           Checked out by <%= book.checked_out_to %>
         <% else %>
           <%= book.current_location %>
-          <div class="check-out"><a href="#">Check out</a></div>
+          <div class="check-out"><%= link("Check out", to: book_check_out_path(@conn, :new, book))%></div>
         <% end %>
       </div>
     </div>

--- a/web/templates/book/show.html.eex
+++ b/web/templates/book/show.html.eex
@@ -27,16 +27,6 @@
     <%= @book.current_location %>
   </li>
 
-  <li>
-    <strong>Checked out:</strong>
-    <%= @book.checked_out %>
-  </li>
-
-  <li>
-    <strong>Checked out to:</strong>
-    <%= @book.checked_out_to %>
-  </li>
-
 </ul>
 
 <%= link "Edit", to: book_path(@conn, :edit, @book) %>

--- a/web/templates/check_out/form.html.eex
+++ b/web/templates/check_out/form.html.eex
@@ -1,0 +1,16 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= text_input f, :checked_out_to, class: "form-control" %>
+    <%= error_tag f, :checked_out_to %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/check_out/index.html.eex
+++ b/web/templates/check_out/index.html.eex
@@ -1,0 +1,26 @@
+<h2>Listing check outs</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Book</th>
+      <th>Checked out to</th>
+      <th>Return date</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for check_out <- @check_outs do %>
+    <tr>
+      <td><%= check_out.book_id %></td>
+      <td><%= check_out.checked_out_to %></td>
+      <td><%= check_out.return_date %></td>
+
+      <td class="text-right">
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+

--- a/web/templates/check_out/new.html.eex
+++ b/web/templates/check_out/new.html.eex
@@ -1,0 +1,6 @@
+<h2>Enter your name to check out <%= @conn.assigns[:book].title %></h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: book_check_out_path(@conn, :create, @conn.assigns[:book]) %>
+
+<%= link "Back", to: book_check_out_path(@conn, :index, @conn.assigns[:book]) %>

--- a/web/views/check_out_view.ex
+++ b/web/views/check_out_view.ex
@@ -1,0 +1,3 @@
+defmodule Bookish.CheckOutView do
+  use Bookish.Web, :view
+end


### PR DESCRIPTION
- Removes original checked_out and checked_out_to database fields
in favor or a separate CheckOut object that is associated with
a book. This allows the app to keep a record of every time a book
was checked out, and possibly use the same CheckOut model for other
types of materials in the future.

- Add a Circulation controller class that interacts with the Book
and CheckOut models

- Add custom queries for the CheckOut class to return books
currently checked out

- Add virtual attributes to books to determine whether a book is
checked out and who it is checked out to

- Add validations to ensure a book is only checked out once