### PR TITLE
Add basic pagination

### DIFF
--- a/test/controllers/book_controller_test.exs
+++ b/test/controllers/book_controller_test.exs
@@ -8,8 +8,13 @@ defmodule Bookish.BookControllerTest do
   @invalid_attrs %{}
   @user %{id: "email", name: "user"}
 
-  test "lists all books on index", %{conn: conn} do
+  test "index redirects to page 1", %{conn: conn} do
     conn = get conn, book_path(conn, :index)
+    assert conn.status == 302
+  end
+
+  test "lists all books on index", %{conn: conn} do
+    conn = get conn, book_path(conn, :paginate, 1)
     assert conn.status == 200
   end
 
@@ -28,7 +33,7 @@ defmodule Bookish.BookControllerTest do
     Ecto.build_assoc(book, :check_outs, borrower_name: "Becca")
     |> Repo.insert!
 
-    conn = get conn, book_path(conn, :index)
+    conn = get conn, book_path(conn, :paginate, 1)
 
     assert html_response(conn, 200) =~ "Becca"
   end
@@ -36,7 +41,7 @@ defmodule Bookish.BookControllerTest do
   test "if a book is not checked out, index displays a link to check out the book", %{conn: conn} do
     Repo.insert! %Book{title: "This is my book"}
 
-    conn = get conn, book_path(conn, :index)
+    conn = get conn, book_path(conn, :paginate, 1)
 
     assert html_response(conn, 200) =~ "Check out"
     assert html_response(conn, 200) =~ "This is my book"
@@ -47,7 +52,7 @@ defmodule Bookish.BookControllerTest do
     Ecto.build_assoc(book, :check_outs, borrower_name: "Becca")
     |> Repo.insert!
 
-    conn = get conn, book_path(conn, :index)
+    conn = get conn, book_path(conn, :paginate, 1)
 
     assert html_response(conn, 200) =~ "checked-out"
   end
@@ -55,7 +60,7 @@ defmodule Bookish.BookControllerTest do
   test "if a book is not checked out, the div has the class 'available'", %{conn: conn} do
     Repo.insert! %Book{title: "This book is not checked out"}
 
-    conn = get conn, book_path(conn, :index)
+    conn = get conn, book_path(conn, :paginate, 1)
 
     assert html_response(conn, 200) =~ "available"
   end
@@ -137,7 +142,7 @@ defmodule Bookish.BookControllerTest do
     |> assign(:current_user, @user)
     |> post(book_path(conn, :create), book: params)
 
-    conn = get conn, book_path(conn, :index)
+    conn = get conn, book_path(conn, :paginate, 1)
 
     assert html_response(conn, 200) =~ "nice"
     assert html_response(conn, 200) =~ "short"
@@ -151,7 +156,7 @@ defmodule Bookish.BookControllerTest do
     |> assign(:current_user, @user)
     |> post(book_path(conn, :create), book: params)
 
-    conn = get conn, book_path(conn, :index)
+    conn = get conn, book_path(conn, :paginate, 1)
     book = List.first(Repo.all(Book)) |> Repo.preload(:tags)
 
     Enum.each(book.tags, fn(tag) ->
@@ -273,4 +278,5 @@ defmodule Bookish.BookControllerTest do
     assert redirected_to(conn) == "/"
     assert Repo.get(Book, book.id)
   end
+
 end

--- a/test/models/book_test.exs
+++ b/test/models/book_test.exs
@@ -102,4 +102,35 @@ defmodule Bookish.BookTest do
     assert Book.get_by_letter("b") |> Repo.all == [b]
     assert Book.get_by_letter("C") |> Repo.all == []
   end
+
+  test "count returns the number of results in a query" do
+    for _ <- 1..5 do Repo.insert!(%Book{}) end
+    count = 
+      Book
+      |> Book.count
+      |> Repo.all
+      |> List.first
+
+    assert count == 5
+  end
+
+  test "paginate returns the number of entries offset by the page number" do
+    for _ <- 1..12 do Repo.insert!(%Book{}) end
+    entries_per_page = 10
+    page_1 = 
+      Book
+      |> Book.paginate(1, entries_per_page)
+      |> Repo.all
+    page_1_count = length(page_1)
+
+    assert page_1_count == 10
+
+    page_2 = 
+      Book
+      |> Book.paginate(2, entries_per_page)
+      |> Repo.all
+    page_2_count = length(page_2)
+
+    assert page_2_count == 2
+  end
 end

--- a/web/helpers/view_helpers.ex
+++ b/web/helpers/view_helpers.ex
@@ -6,6 +6,14 @@ defmodule Bookish.ViewHelpers do
       "available"
     end
   end
+
+  def get_number_class(n, current_page) when n == current_page do
+    "disabled"
+  end
+
+  def get_number_class(_, _) do
+    "enabled"
+  end
 end
 
 

--- a/web/models/book.ex
+++ b/web/models/book.ex
@@ -48,13 +48,25 @@ defmodule Bookish.Book do
   
   def sorted_by_title do
     from b in Bookish.Book,
-    order_by: b.title,
-    select: b
+      order_by: b.title,
+      select: b
   end
 
   def get_by_letter(letter) do
     from b in Bookish.Book,
-    where: ilike(b.title, ^"#{letter}%"),
-    select: b
+      where: ilike(b.title, ^"#{letter}%"),
+      order_by: b.title,
+      select: b
+  end
+
+  def paginate(query, page, size) do
+    from b in query,
+      limit: ^size,
+      offset: ^((page-1) * size)
+  end
+
+  def count(query) do
+    from b in query,
+      select: count(b.id)
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -17,6 +17,7 @@ defmodule Bookish.Router do
   scope "/books", Bookish do
     pipe_through :browser
     get "/starting-with/:letter", BookController, :index_by_letter, as: :book
+    get "/page/:number", BookController, :paginate, as: :book
     get "/checked_out", Circulation, :checked_out, as: :circulation
     get "/:id/return", Circulation, :return, as: :circulation
     post "/:id/return", Circulation, :process_return, as: :circulation

--- a/web/static/css/index-page.scss
+++ b/web/static/css/index-page.scss
@@ -90,3 +90,22 @@ $location-color: #EF4836;
   }
 }
 
+.pagination {
+  span {
+    margin: $default-margin / 2;
+    font-weight: 700;
+  }
+  text-align: center;
+  .disabled {
+    pointer-events: none;
+  }
+  .enabled {
+    a {
+      color: $green;
+      &:hover {
+        color: lighten($green, 10%)
+      }
+    }
+  }
+}
+

--- a/web/templates/book/index.html.eex
+++ b/web/templates/book/index.html.eex
@@ -19,8 +19,19 @@
   <% end %>
 </div>
 <br>
+
 <%= link to: book_path(@conn, :new) do %>
   <div class="bold-text">
     <i class="fa fa-plus-circle"></i> Add a book
   </div>
 <% end %>
+
+<div class="pagination">
+  <%= for n <- 1..@page_count do %>
+    <%= if @page_count > 1 do %>
+      <span class="<%= get_number_class(n, @current_page) %>">
+        <a href="<%= n %>"><%= n %></a>
+      </span>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
Currently, the index page redirects automatically to page 1. Ten books
are shown per page, and page links appear at the bottom of the page.

To do: Add pagination to filtered results (by letter,
checked-out/available)